### PR TITLE
fix: tweets createdAt & replies createdAt

### DIFF
--- a/seeders/20221004035722-seeder-tweet-files.js.js
+++ b/seeders/20221004035722-seeder-tweet-files.js.js
@@ -12,7 +12,7 @@ module.exports = {
       tweets.push(...Array.from({ length: TWEETS_PER_USERS }, () => ({
         UserId: user.id,
         description: faker.lorem.sentence(6),
-        createdAt: faker.date.between('2022-09-01T00:00:00.000Z', '2022-10-01T00:00:00.000Z'),
+        createdAt: faker.date.between('2022-09-01T00:00:00.000Z', '2022-09-15T00:00:00.000Z'),
         updatedAt: new Date()
       })))
     })

--- a/seeders/20221004043909-seeder-reply-files.js
+++ b/seeders/20221004043909-seeder-reply-files.js
@@ -20,7 +20,7 @@ module.exports = {
           UserId: user.id,
           TweetId: tweets[Math.floor(Math.random() * tweets.length)].id,
           comment: faker.lorem.sentence(3),
-          createdAt: faker.date.between('2022-09-01T00:00:00.000Z', '2022-10-01T00:00:00.000Z'),
+          createdAt: faker.date.between('2022-09-16T00:00:00.000Z', '2022-10-01T00:00:00.000Z'),
           updatedAt: new Date()
         }))
       )
@@ -38,7 +38,7 @@ module.exports = {
             UserId,
             TweetId: tweet.id,
             comment: faker.lorem.sentence(3),
-            createdAt: faker.date.between('2022-09-01T00:00:00.000Z', '2022-10-01T00:00:00.000Z'),
+            createdAt: faker.date.between('2022-09-16T00:00:00.000Z', '2022-10-01T00:00:00.000Z'),
             updatedAt: new Date()
           }
         }))


### PR DESCRIPTION
我先直接把生成 tweet createdAt的時間跟replies createdAt 的時間劃分開來，我目前還沒有想到該怎麼把 createdAt 跟 updatedAt 的時間弄成一樣的，而且我覺得這個的優先級也沒這麼高，所以先這樣

上次我提到的 admin 會被追蹤這個問題好像不是種子的問題，而是我開發測試的時候加進去的，所以我沒動